### PR TITLE
Add LRU statement cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ sqlparser = "0.37"
 async-trait = "0.1"
 chrono = "0.4"
 tracing = "0.1.37"
+lrumap = "0.1.0"
 
 # Cannot nest Workspaces
 # [workspace]


### PR DESCRIPTION
Uses the lrumap crate.

Defaults to `9999` statements. 

A simple query works out to be roughly 50kb
10,000 statements requires about 5MB of memory. 