### PR TITLE
Make writing to the wire more good 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ async-trait = "0.1"
 chrono = "0.4"
 tracing = "0.1.37"
 
+[dev-dependencies]
+rand = "0.8.5"
+
 # Cannot nest Workspaces
 # [workspace]
 # members = [

--- a/convergence/src/lib.rs
+++ b/convergence/src/lib.rs
@@ -6,3 +6,4 @@ pub mod engine;
 pub mod protocol;
 pub mod protocol_ext;
 pub mod server;
+pub mod to_wire;

--- a/convergence/src/protocol_ext.rs
+++ b/convergence/src/protocol_ext.rs
@@ -1,8 +1,10 @@
 //! Contains extensions that make working with the Postgres protocol simpler or more efficient.
 
-use crate::{protocol::{ConnectionCodec, FormatCode, ProtocolError, RowDescription}, to_wire::{Writer, ToWire}};
+use crate::{
+	protocol::{ConnectionCodec, FormatCode, ProtocolError, RowDescription},
+	to_wire::{ToWire, Writer},
+};
 use bytes::{BufMut, Bytes, BytesMut};
-use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use tokio_util::codec::Encoder;
 
 /// Supports batched rows for e.g. returning portal result sets.
@@ -71,18 +73,6 @@ impl DataRowBatch {
 	}
 }
 
-macro_rules! primitive_write {
-	($name: ident, $type: ident) => {
-		#[allow(missing_docs)]
-		pub fn $name(&mut self, val: $type) {
-			match self.parent.format_code {
-				FormatCode::Text => self.write_value(&val.to_string().into_bytes()),
-				FormatCode::Binary => self.write_value(&val.to_be_bytes()),
-			};
-		}
-	};
-}
-
 /// Temporarily leased from a [DataRowBatch] to encode a single row.
 pub struct DataRowWriter<'a> {
 	current_col: usize,
@@ -92,10 +82,21 @@ pub struct DataRowWriter<'a> {
 impl Writer for DataRowWriter<'_> {
 	fn write<T>(&mut self, val: T)
 	where
-		T: ToWire {
+		T: ToWire,
+	{
 		match self.parent.format_code {
-			FormatCode::Text => self.write_value(&val.to_binary()),
-			FormatCode::Binary => self.write_value(&val.to_text()),
+			FormatCode::Binary => self.write_value(&val.to_binary()),
+			FormatCode::Text => self.write_value(&val.to_text()),
+		};
+	}
+
+	fn write_nullable<T>(&mut self, val: Option<T>)
+	where
+		T: ToWire,
+	{
+		match val {
+			Some(val) => self.write(val),
+			None => self.write_null(),
 		};
 	}
 }
@@ -111,6 +112,7 @@ impl<'a> DataRowWriter<'a> {
 			self.current_col < self.parent.num_cols,
 			"tried to write more columns than specified in row description"
 		);
+
 		self.current_col += 1;
 		self.parent.row.put_i32(data.len() as i32);
 		self.parent.row.put_slice(data);
@@ -121,79 +123,6 @@ impl<'a> DataRowWriter<'a> {
 		self.current_col += 1;
 		self.parent.row.put_i32(-1);
 	}
-
-	/// Writes raw bytes for the next column.
-	pub fn write_bytes(&mut self, data: Bytes) {
-		self.current_col += 1;
-		self.parent.row.put_i32(data.len() as i32);
-		self.parent.row.put_slice(data.as_ref());
-	}
-
-	/// Writes a string value for the next column.
-	pub fn write_string(&mut self, val: &str) {
-		self.write_value(val.as_bytes());
-	}
-
-	/// Writes a bool value for the next column.
-	pub fn write_bool(&mut self, val: bool) {
-		match self.parent.format_code {
-			FormatCode::Text => self.write_value(if val { "t" } else { "f" }.as_bytes()),
-			FormatCode::Binary => {
-				self.current_col += 1;
-				self.parent.row.put_u8(val as u8);
-			}
-		};
-	}
-
-	fn pg_date_epoch() -> NaiveDate {
-		NaiveDate::from_ymd_opt(2000, 1, 1).expect("failed to create pg date epoch")
-	}
-
-	fn pg_timestamp_epoch() -> NaiveDateTime {
-		Self::pg_date_epoch()
-			.and_hms_opt(0, 0, 0)
-			.expect("failed to create pg timestamp epoch")
-	}
-
-	/// Writes a date value for the next column.
-	pub fn write_date(&mut self, val: NaiveDate) {
-		match self.parent.format_code {
-			FormatCode::Binary => self.write_int4(val.signed_duration_since(Self::pg_date_epoch()).num_days() as i32),
-			FormatCode::Text => self.write_string(&val.to_string()),
-		}
-	}
-
-	/// Writes a time value for the next column.
-	pub fn write_time(&mut self, val: NaiveTime) {
-		match self.parent.format_code {
-			FormatCode::Binary => {
-				let delta = val.signed_duration_since(NaiveTime::from_hms_opt(0, 0, 0).unwrap());
-				let time = delta.num_microseconds().unwrap_or(0);
-				self.write_int8(time);
-			}
-			FormatCode::Text => self.write_string(&val.to_string()),
-		}
-	}
-
-	/// Writes a timestamp value for the next column.
-	pub fn write_timestamp(&mut self, val: NaiveDateTime) {
-		match self.parent.format_code {
-			FormatCode::Binary => {
-				self.write_int8(
-					val.signed_duration_since(Self::pg_timestamp_epoch())
-						.num_microseconds()
-						.unwrap(),
-				);
-			}
-			FormatCode::Text => self.write_string(&val.to_string()),
-		}
-	}
-	primitive_write!(write_char, i8);
-	primitive_write!(write_int2, i16);
-	primitive_write!(write_int4, i32);
-	primitive_write!(write_int8, i64);
-	primitive_write!(write_float4, f32);
-	primitive_write!(write_float8, f64);
 }
 
 impl<'a> Drop for DataRowWriter<'a> {
@@ -224,7 +153,7 @@ mod tests {
 
 	use crate::protocol::FormatCode;
 
-	use super::DataRowBatch;
+	use super::{DataRowBatch, Writer};
 
 	// DataRow (B)
 	// https://www.postgresql.org/docs/current/protocol-message-formats.html
@@ -257,7 +186,7 @@ mod tests {
 				let expected_columns = 1;
 				let expected_id = b'D';
 
-				row.$name(expected_val);
+				row.write(expected_val);
 				drop(row); // Drop the row to write to the batch
 
 				let message_id = 0..1;
@@ -290,14 +219,15 @@ mod tests {
 
 				let data: [u8; EXPECTED_LEN as usize] = bytes[val].try_into().expect("Expected $type");
 				let data = $type::from_be_bytes(data);
+
 				assert_eq!(data, expected_val);
 			}
 		};
 	}
 
-	test_primitive_write!(write_int2, i16);
-	test_primitive_write!(write_int4, i32);
-	test_primitive_write!(write_int8, i64);
-	test_primitive_write!(write_float4, f32);
-	test_primitive_write!(write_float8, f64);
+	test_primitive_write!(test_write_int2, i16);
+	test_primitive_write!(test_write_int4, i32);
+	test_primitive_write!(test_write_int8, i64);
+	test_primitive_write!(test_write_float4, f32);
+	test_primitive_write!(test_write_float8, f64);
 }

--- a/convergence/src/server.rs
+++ b/convergence/src/server.rs
@@ -85,7 +85,12 @@ pub async fn run_with_tcp<E: Engine>(bind: BindOptions, engine_func: EngineFunc<
 		let engine_func = engine_func.clone();
 		tokio::spawn(async move {
 			let mut conn = Connection::new(engine_func().await);
-			conn.run(stream).await.unwrap();
+			let result = conn.run(stream).await;
+
+			if let Err(ConnectionError::ConnectionClosed) = result {
+				//Broken Pipe - client disconnected
+				tracing::warn!("Connection closed by client");
+			}
 		});
 	}
 }

--- a/convergence/src/to_wire.rs
+++ b/convergence/src/to_wire.rs
@@ -1,0 +1,195 @@
+use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+
+const NULL: i32 = -1;
+
+struct Null {}
+
+pub trait Writer {
+	fn write<T>(&mut self, val: T)
+	where
+		T: ToWire;
+}
+
+pub trait ToWire {
+	fn to_binary(&self) -> Vec<u8>;
+
+	fn to_text(&self) -> Vec<u8>;
+}
+
+impl<T: ToWire> ToWire for Option<T> {
+	fn to_binary(&self) -> Vec<u8> {
+		match self {
+			Some(ref val) => val.to_binary(),
+			None => NULL.to_binary(),
+		}
+	}
+	fn to_text(&self) -> Vec<u8> {
+		match self {
+			Some(ref val) => val.to_text(),
+			None => NULL.to_binary(),
+		}
+	}
+}
+
+impl ToWire for bool {
+	fn to_binary(&self) -> Vec<u8> {
+		(*self as u8).to_be_bytes().into()
+	}
+	fn to_text(&self) -> Vec<u8> {
+		if *self { "t" } else { "f" }.as_bytes().into()
+	}
+}
+
+fn pg_date_epoch() -> NaiveDate {
+	NaiveDate::from_ymd_opt(2000, 1, 1).expect("failed to create pg date epoch")
+}
+
+fn pg_timestamp_epoch() -> NaiveDateTime {
+	pg_date_epoch()
+		.and_hms_opt(0, 0, 0)
+		.expect("failed to create pg timestamp epoch")
+}
+
+impl ToWire for NaiveDate {
+	fn to_binary(&self) -> Vec<u8> {
+		let d: i32 = self.signed_duration_since(pg_date_epoch()).num_days() as i32;
+		d.to_binary()
+	}
+	fn to_text(&self) -> Vec<u8> {
+		self.to_string().as_bytes().into()
+	}
+}
+
+impl ToWire for NaiveDateTime {
+	fn to_binary(&self) -> Vec<u8> {
+		let dt: i64 = self
+			.signed_duration_since(pg_timestamp_epoch())
+			.num_microseconds()
+			.unwrap();
+		dt.to_binary()
+	}
+	fn to_text(&self) -> Vec<u8> {
+		self.to_string().as_bytes().into()
+	}
+}
+
+impl ToWire for NaiveTime {
+	fn to_binary(&self) -> Vec<u8> {
+		let delta = self.signed_duration_since(NaiveTime::from_hms_opt(0, 0, 0).unwrap());
+		let t = delta.num_microseconds().unwrap_or(0);
+		t.to_binary()
+	}
+	fn to_text(&self) -> Vec<u8> {
+		self.to_string().as_bytes().into()
+	}
+}
+
+macro_rules! to_wire {
+	($type: ident) => {
+		#[allow(missing_docs)]
+		impl ToWire for $type {
+			fn to_binary(&self) -> Vec<u8> {
+				self.to_be_bytes().into()
+			}
+			fn to_text(&self) -> Vec<u8> {
+				self.to_string().as_bytes().into()
+			}
+		}
+	};
+}
+
+to_wire!(i8);
+to_wire!(i16);
+to_wire!(i32);
+to_wire!(i64);
+to_wire!(f32);
+to_wire!(f64);
+
+#[cfg(test)]
+mod tests {
+	use bytes::{BufMut, BytesMut};
+	use rand::Rng;
+	use std::{convert::TryInto, mem};
+
+	use super::{ToWire, Writer};
+
+	struct TestWriter {
+		pub buf: BytesMut,
+	}
+
+	impl Writer for TestWriter {
+		fn write<T>(&mut self, val: T)
+		where
+			T: ToWire,
+		{
+			self.buf.put_slice(&val.to_binary());
+		}
+	}
+
+	macro_rules! test_to_wire {
+		($name: ident, $type: ident) => {
+			#[test]
+			pub fn $name() {
+				const LEN: usize = mem::size_of::<$type>();
+
+				let min: $type = 0 as $type;
+				let max: $type = $type::MAX;
+
+				let mut rng = rand::thread_rng();
+				let expected: $type = rng.gen_range(min..max);
+
+				let val: $type = expected;
+
+				let mut w = TestWriter { buf: BytesMut::new() };
+				w.write(val);
+
+				let data: [u8; LEN] = w.buf[..LEN].try_into().expect("Expected $type");
+				let out = $type::from_be_bytes(data);
+
+                assert_eq!(expected, out);
+
+                // Option<T>
+                let val: Option<$type> = Some(expected);
+
+				let mut w = TestWriter { buf: BytesMut::new() };
+				w.write(val);
+
+				let data: [u8; LEN] = w.buf[..LEN].try_into().expect("Expected $type");
+				let out = $type::from_be_bytes(data);
+
+				assert_eq!(expected, out);
+			}
+		};
+	}
+
+	macro_rules! test_to_wire_null {
+		($name: ident, $type: ident) => {
+			#[tokio::test]
+			pub async fn $name() {
+                // Option<T>
+                let val: Option<$type> = None;
+
+				let mut w = TestWriter { buf: BytesMut::new() };
+				w.write(val);
+
+				let data: [u8; 4] = w.buf[..4].try_into().expect("Expected $type");
+				let out = i32::from_be_bytes(data);
+
+                let expected: i32 = -1;
+				assert_eq!(expected, out);
+			}
+		};
+	}
+
+	test_to_wire!(test_to_wire_i16, i16);
+	test_to_wire!(test_to_wire_i32, i32);
+	test_to_wire!(test_to_wire_i64, i64);
+	test_to_wire!(test_to_wire_f32, f32);
+	test_to_wire!(test_to_wire_f64, f64);
+
+	test_to_wire_null!(test_to_wire_null_i16, i16);
+	test_to_wire_null!(test_to_wire_null_i32, i32);
+	test_to_wire_null!(test_to_wire_null_i64, i64);
+	test_to_wire_null!(test_to_wire_null_f32, f32);
+	test_to_wire_null!(test_to_wire_null_f64, f64);
+}


### PR DESCRIPTION
Adds a `ToWire` trait that any type can implement to generate byte representations for sending using the PG protocol via TCP. 

Refactors the `DataRowWriter` to use the new trait for writing. 

Adds a new `Writer` trait for slightly more convenient testing. 