### PR TITLE
Expand Protocol 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,6 @@ sqlparser = "0.39.0"
 async-trait = "0.1"
 chrono = "0.4"
 tracing = "0.1.37"
-
-[dev-dependencies]
 rand = "0.8.5"
 
 # Cannot nest Workspaces

--- a/convergence/src/connection.rs
+++ b/convergence/src/connection.rs
@@ -285,12 +285,10 @@ impl<E: Engine> Connection<E> {
 							Some(bound) => {
 								let mut batch_writer = DataRowBatch::from_row_desc(&bound.row_desc);
 
-								tracing::debug!("Portal.Execute");
+								tracing::debug!("Connection.Portal.Execute");
 								bound.portal.execute(&mut batch_writer).await?;
 
 								let num_rows = batch_writer.num_rows();
-
-								tracing::debug!("Send");
 
 								framed.send(batch_writer).await?;
 
@@ -301,6 +299,7 @@ impl<E: Engine> Connection<E> {
 									.await?;
 							}
 							None => {
+								tracing::debug!("Connection.Portal.None");
 								framed.send(EmptyQueryResponse).await?;
 							}
 						}

--- a/convergence/src/engine.rs
+++ b/convergence/src/engine.rs
@@ -25,7 +25,12 @@ pub trait Engine: Send + Sync + 'static {
 
 	/// Prepares a statement, returning a vector of field descriptions for the final statement result.
 	// async fn prepare(&mut self, stmt: &Statement) -> Result<Vec<FieldDescription>, ErrorResponse>;
-	async fn prepare(&mut self, stmt_name: &str, stmt: &Statement) -> Result<StatementDescription, ErrorResponse>;
+	async fn prepare(
+		&mut self,
+		stmt_name: &str,
+		stmt: &Statement,
+		parameter_types: Vec<DataTypeOid>,
+	) -> Result<StatementDescription, ErrorResponse>;
 
 	/// Creates a new portal for a prepared statement and passings params for decoding.
 	async fn create_portal(

--- a/convergence/src/protocol.rs
+++ b/convergence/src/protocol.rs
@@ -888,12 +888,20 @@ impl Decoder for ConnectionCodec {
 				})
 			}
 			b'E' => {
-				let portal = read_cstr(src)?;
-				let max_rows = match src.get_i32() {
-					0 => None,
-					other => Some(other),
-				};
+				// Byte1('E')
+				//   Identifies the message as an Execute command.
+				// Int32
+				//   Length of message contents in bytes, including self.
+				// String
+				// 	 The name of the portal to execute (an empty string selects the unnamed portal).
+				// Int32
+				//   Maximum number of rows to return, if portal contains a query that returns rows (ignored otherwise). Zero denotes “no limit”.
 
+				tracing::debug!("EXECUTE.src {:?}", &src);
+
+				let portal = read_cstr(src)?;
+
+				let max_rows = if src.is_empty() { None } else { Some(src.get_i32()) };
 				ClientMessage::Execute(Execute { portal, max_rows })
 			}
 			b'Q' => {

--- a/convergence/src/protocol.rs
+++ b/convergence/src/protocol.rs
@@ -825,8 +825,21 @@ impl Decoder for ConnectionCodec {
 				})
 			}
 			b'D' => {
+				// 	Byte1('D')
+				// 	Identifies the message as a Describe command.
+
+				// Int32
+				// 	Length of message contents in bytes, including self.
+
+				// Byte1
+				// 	'S' to describe a prepared statement; or 'P' to describe a portal.
+
+				// String
+				// 	The name of the prepared statement or portal to describe (an empty string selects the unnamed prepared statement or portal).
+				tracing::debug!("ClientMessage::Describe src {:?}", &src);
+
 				let target_type = src.get_u8();
-				let name = read_cstr(src)?;
+				let name = read_cstr(src).unwrap_or("".to_string());
 
 				ClientMessage::Describe(match target_type {
 					b'P' => Describe::Portal(name),


### PR DESCRIPTION
- Connections now generate a random ID and this is passed with the trace messages. Handy for working out flow when multiple connections are running. 

- Clients can specify the parameter types with a PARSE message. We now pass those parameter types through to the connection. Requires change in the proxy engine to support.

- Change to handling of max_rows parameter in `Execute`. Protocol says:
```
Int32
Maximum number of rows to return, if portal contains a query that returns rows (ignored otherwise). Zero denotes “no limit”.
```
Code made the assumption that the value must be present (but may be ignored if not relevant). However, it looks like the `ignored otherwise` means optional as pgbench does not include the value and then things explode.

- Couple of fixes for some other strange pgbench behaviour. For some reason, pgbench seems to encode zero values at the end of a string as i8 and not i16, when the message format clearly specifies i16. Ended up using wireshark to confirm the behaviour. Seems like an easy fix to check the source buffer length and drop to i8 if there are not enough bytes.  