### PR TITLE
Handle empty message

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,7 @@ async-trait = "0.1"
 chrono = "0.4"
 tracing = "0.1.37"
 rand = "0.8.5"
+pretty_assertions = "1.4.0"
 
-# Cannot nest Workspaces
-# [workspace]
-# members = [
-# 	"convergence",
-# 	"convergence-arrow",
-# ]
+[dev-dependencies]
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }


### PR DESCRIPTION
So ... it turns out that sending an empty message "" is the way that some clients check that the connection to the server is still open. 

Thanks for nothing. 