### PR TITLE
Fix for leading zero and wrong nunber of bytes in execute

### DIFF
--- a/convergence/src/connection.rs
+++ b/convergence/src/connection.rs
@@ -280,12 +280,12 @@ impl<E: Engine> Connection<E> {
 						framed.send(ReadyForQuery).await?;
 					}
 					ClientMessage::Execute(exec) => {
-						tracing::debug!("Connection.Execute {}", self.id);
+						tracing::debug!("Connection.Execute {}", &self.id);
+
 						match self.portal_mut(&exec.portal)? {
 							Some(bound) => {
 								let mut batch_writer = DataRowBatch::from_row_desc(&bound.row_desc);
 
-								tracing::debug!("Connection.Portal.Execute");
 								bound.portal.execute(&mut batch_writer).await?;
 
 								let num_rows = batch_writer.num_rows();
@@ -299,7 +299,7 @@ impl<E: Engine> Connection<E> {
 									.await?;
 							}
 							None => {
-								tracing::debug!("Connection.Portal.None");
+								tracing::debug!("Connection.Portal.None {}", &self.id);
 								framed.send(EmptyQueryResponse).await?;
 							}
 						}


### PR DESCRIPTION
Handle a couple of cases from pgbench and python

- occasional leading zeros in messages
- execute with incorrect number of bytes

I've read the message format about a gazillion times and I've dived into the tcp handling and I really don't think the leading byte is anything I am doing. Stripping it out seems to work. 

Other weird thing is Execute having the wrong number of bytes for `max_rows`. I have not seen this be anything other than `0` as `LIMIT` exists. So the max_rows isn't even used atm. Fix is to assume `0` value and then clear the buffer.