### PR TITLE
WIP Add minimal logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ chrono = "0.4"
 tracing = "0.1.37"
 rand = "0.8.5"
 pretty_assertions = "1.4.0"
+uuid = "1.5.0"
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,10 @@ sqlparser = "0.39.0"
 async-trait = "0.1"
 chrono = "0.4"
 tracing = "0.1.37"
-rand = "0.8.5"
-pretty_assertions = "1.4.0"
-uuid = "1.5.0"
+
+uuid = { version = "1.5.0", featutres = ["fast-rng", "v4"] }
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+pretty_assertions = "1.4.0"
+rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = "0.1"
 chrono = "0.4"
 tracing = "0.1.37"
 
-uuid = { version = "1.5.0", featutres = ["fast-rng", "v4"] }
+uuid = { version = "1.5.0", features = ["fast-rng", "v4"] }
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }

--- a/convergence/src/connection.rs
+++ b/convergence/src/connection.rs
@@ -8,7 +8,6 @@ use sqlparser::ast::Statement;
 use sqlparser::dialect::PostgreSqlDialect;
 use sqlparser::parser::Parser;
 use std::collections::HashMap;
-// use std::fmt;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::codec::Framed;
 use tracing::{Instrument, Level};
@@ -206,7 +205,6 @@ impl<E: Engine> Connection<E> {
 							Some(statement) => {
 								let params = prepared.parameters;
 								let binding = bind.parameters;
-								// let format = bind.result_format;
 
 								if binding.len() != params.len() {
 									return Err(ErrorResponse::error(

--- a/convergence/src/connection.rs
+++ b/convergence/src/connection.rs
@@ -11,6 +11,7 @@ use std::collections::HashMap;
 // use std::fmt;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::codec::Framed;
+use uuid::Uuid;
 
 /// Describes an error that may or may not result in the termination of a connection.
 #[derive(thiserror::Error, Debug)]
@@ -51,23 +52,18 @@ struct BoundPortal<E: Engine> {
 /// Describes a connection using a specific engine.
 /// Contains connection state including prepared statements and portals.
 pub struct Connection<E: Engine> {
-	id: String,
+	pub id: Uuid,
 	engine: E,
 	state: ConnectionState,
 	statements: HashMap<String, PreparedStatement>,
 	portals: HashMap<String, Option<BoundPortal<E>>>,
 }
 
-fn id() -> String {
-	use rand::distributions::{Alphanumeric, DistString};
-	Alphanumeric.sample_string(&mut rand::thread_rng(), 24).to_lowercase()
-}
-
 impl<E: Engine> Connection<E> {
 	/// Create a new connection from an engine instance.
 	pub fn new(engine: E) -> Self {
 		Self {
-			id: id(),
+			id: Uuid::new_v4(),
 			state: ConnectionState::Startup,
 			statements: HashMap::new(),
 			portals: HashMap::new(),


### PR DESCRIPTION
Main change is logging the query string on Execute
https://github.com/cipherstash/convergence/commit/d24334505683374dc0bdca2e08f211a7a972af6c

Adds ergonomic changes 
- connection id as UUID
- connection_id in debug context
- span and instrument so that traces inside engine and portal will be in the connection span context