### PR TITLE
Handle per-parameter format codes

### DIFF
--- a/convergence/src/engine.rs
+++ b/convergence/src/engine.rs
@@ -39,7 +39,7 @@ pub trait Engine: Send + Sync + 'static {
 		stmt: &Statement,
 		params: Vec<DataTypeOid>,
 		binding: Vec<Bytes>,
-		format: FormatCode,
+		param_format_codes: Vec<FormatCode>,
 	) -> Result<Self::PortalType, ErrorResponse>;
 
 	/// Queries directly without setting up a portal


### PR DESCRIPTION
I missed that the format codes in Bind are handled twice
- parameters
- results

Convergence  is responsible for ensuring that there is a corresponding FormatCode for each parameter. 
The Engine is passed a vec of format codes equal to the param length. Avoids the engine having to have any logic about ALL vs per-column format. 

Change to support `parameters` from the protocol.

Message format is:

```
Int16
The number of parameter format codes that follow (denoted C below). This can be zero to indicate that there are no parameters or that the parameters all use the default format (text); or one, in which case the specified format code is applied to all parameters; or it can equal the actual number of parameters.

Int16[C]
  The parameter format codes. Each must presently be zero (text) or one (binary).

```

The implementation is therefore:
```
0 - No Parameters or Default
1 -  Format Code used for all parameters
n - Format Code for each parameter
```
