### PR TITLE
Pass Engine raw query instead of the currently unused parsed statement

### DIFF
--- a/convergence/src/connection.rs
+++ b/convergence/src/connection.rs
@@ -37,7 +37,7 @@ enum ConnectionState {
 #[derive(Debug, Clone)]
 /// Wraps Parsed Statement and associated metadata
 pub struct PreparedStatement {
-	pub query: String,
+	pub statement: String,
 	pub fields: Vec<FieldDescription>,
 	pub parameters: Vec<DataTypeOid>,
 }
@@ -168,7 +168,7 @@ impl<E: Engine> Connection<E> {
 							.await?;
 
 						let prepared_statement = PreparedStatement {
-							query: parse.query.to_owned(),
+							statement: parse.query.to_owned(),
 							parameters: statement_description.parameters.unwrap_or(vec![]),
 							fields: statement_description.fields.unwrap_or(vec![]),
 						};
@@ -196,7 +196,7 @@ impl<E: Engine> Connection<E> {
 
 						match prepared {
 							Ok(prepared) => {
-								tracing::debug!("Connection.Bind {} Prepared={}", self.id, &prepared.query);
+								tracing::debug!("Connection.Bind {} Prepared={}", self.id, &prepared.statement);
 
 								let params = prepared.parameters.to_owned();
 								let binding = bind.parameters.to_owned();

--- a/convergence/src/connection.rs
+++ b/convergence/src/connection.rs
@@ -157,9 +157,6 @@ impl<E: Engine> Connection<E> {
 					ClientMessage::Parse(parse) => {
 						tracing::debug!("Connection.Parse {}", self.id);
 
-						// let parsed_statement = self.parse_statement(&parse.query)?;
-						// tracing::debug!("Statement {} {:?}", self.id, parsed_statement);
-
 						tracing::debug!("Preparing Statement Engine {}", self.id);
 
 						let statement_description = self

--- a/convergence/src/connection.rs
+++ b/convergence/src/connection.rs
@@ -255,8 +255,7 @@ impl<E: Engine> Connection<E> {
 									self.id,
 									&bind.prepared_statement_name
 								);
-
-								self.portals.insert(bind.portal, None);
+								return Err(err);
 							}
 						}
 

--- a/convergence/src/engine.rs
+++ b/convergence/src/engine.rs
@@ -28,15 +28,14 @@ pub trait Engine: Send + Sync + 'static {
 	async fn prepare(
 		&mut self,
 		stmt_name: &str,
-		stmt: &Statement,
+		query: &str,
 		parameter_types: Vec<DataTypeOid>,
 	) -> Result<StatementDescription, ErrorResponse>;
 
 	/// Creates a new portal for a prepared statement and passings params for decoding.
 	async fn create_portal(
-		&mut self,
+		&self,
 		stmt_name: &str,
-		stmt: &Statement,
 		params: Vec<DataTypeOid>,
 		binding: Vec<Bytes>,
 		param_format_codes: Vec<FormatCode>,

--- a/convergence/src/engine.rs
+++ b/convergence/src/engine.rs
@@ -28,7 +28,7 @@ pub trait Engine: Send + Sync + 'static {
 	async fn prepare(
 		&mut self,
 		stmt_name: &str,
-		query: &str,
+		statement: &str,
 		parameter_types: Vec<DataTypeOid>,
 	) -> Result<StatementDescription, ErrorResponse>;
 

--- a/convergence/src/protocol.rs
+++ b/convergence/src/protocol.rs
@@ -820,9 +820,6 @@ impl Decoder for ConnectionCodec {
 				let target_type = src.get_u8();
 				let name = read_cstr(src).unwrap_or("".to_string());
 
-				tracing::debug!("target_type {:?}", target_type);
-				tracing::debug!("name {:?}", name);
-
 				// P - ASCII 80
 				// S - ASCII 83
 				ClientMessage::Describe(match target_type {
@@ -904,6 +901,9 @@ impl Decoder for ConnectionCodec {
 				for _ in 0..num_params {
 					let param_len = src.get_i32() as usize;
 					let _bytes = &src[0..param_len];
+
+					tracing::warn!("bytes {:?}", src);
+					tracing::warn!("bytes {:?}", _bytes);
 
 					let b = Bytes::copy_from_slice(_bytes);
 					parameters.push(b);


### PR DESCRIPTION


The change in bind is because we no longer have the reference to an `Option<Statement>`

We weren't using it anyway. This cleans up the logic to handle a missing statement as Result<Error> not as Result<Option>. Was always weird as why is the parsed statement an Option? If you didn't parse it, you have problems